### PR TITLE
Work in progress: download, mash_sketch, and mash_dist rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The Inphared refseq genomes dataset is a subset of genome files and is much smal
 
 ```bash
 wget https://millardlab-inphared.s3.climb.ac.uk/2Jul2023_refseq_genomes.fa.gz    
-gunzip https://millardlab-inphared.s3.climb.ac.uk/2Jul2023_refseq_genomes.fa.gz
+gunzip 2Jul2023_refseq_genomes.fa.gz
 ```
 
 ## 2. Data processing with [Mash](https://github.com/marbl/Mash)  

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -25,9 +25,11 @@ rule mash_sketch:
         prefix=lambda wc , output: os.path.splitext( output.msh )[0],
      conda:
         "envs/mash.yaml"
+     threads:
+          6
      shell:
         """
-        mash sketch -i -k 15 -s 25000 -p 24 -o {params.prefix} {input[0]}
+        mash sketch -i -k 15 -s 25000 -p {threads} -o {params.prefix} {input[0]}
         """
 
 rule mash_dist:
@@ -37,8 +39,10 @@ rule mash_dist:
         tsv="results/mash/{genome_fasta}.d0.3.k15.s25000.tsv"
      conda:
         "envs/mash.yaml"
+     threads:
+          6
      shell:
         """
-        mash dist -i -d 0.3 -p 24 {input.msh} {input.msh} \
+        mash dist -i -d 0.3 -p {threads} {input.msh} {input.msh} \
         > {output.tsv}
         """

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -2,8 +2,9 @@
 import os
 
 rule all:
-     input:
-        tsv="results/mash/2Jul2023_refseq_genomes.d0.3.k15.s25000.tsv"
+    input:
+        tsv="results/mash/three-aeromonas-phage-genomes.d0.3.k15.s25000.tsv"
+        #tsv="results/mash/2Jul2023_refseq_genomes.d0.3.k15.s25000.tsv"
 
 
 rule download:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1,4 +1,44 @@
-# Main entrypoint of the workflow. 
-# Please follow the best practices: 
-# https://snakemake.readthedocs.io/en/stable/snakefiles/best_practices.html,
-# in particular regarding the standardized folder structure mentioned there. 
+
+import os
+
+rule all:
+     input:
+        tsv="results/mash/2Jul2023_refseq_genomes.d0.3.k15.s25000.tsv"
+
+
+rule download:
+     output:
+        "resources/{genome_fasta}.fa",
+     shell:
+        """
+        curl -O https://millardlab-inphared.s3.climb.ac.uk/{wildcards.genome_fasta}.fa.gz;
+        gunzip {wildcards.genome_fasta}.fa.gz;
+        mv {wildcards.genome_fasta}.fa {output[0]}
+        """
+
+rule mash_sketch:
+     input:
+        "resources/{genome_fasta}.fa",
+     output:
+        msh="results/mash/{genome_fasta}.fa.msh",
+     params:
+        prefix=lambda wc , output: os.path.splitext( output.msh )[0],
+     conda:
+        "envs/mash.yaml"
+     shell:
+        """
+        mash sketch -i -k 15 -s 25000 -p 24 -o {params.prefix} {input[0]}
+        """
+
+rule mash_dist:
+     input:
+        msh="results/mash/{genome_fasta}.fa.msh",
+     output:
+        tsv="results/mash/{genome_fasta}.d0.3.k15.s25000.tsv"
+     conda:
+        "envs/mash.yaml"
+     shell:
+        """
+        mash dist -i -d 0.3 -p 24 {input.msh} {input.msh} \
+        > {output.tsv}
+        """

--- a/workflow/envs/mash.yaml
+++ b/workflow/envs/mash.yaml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - mash =2.3


### PR DESCRIPTION
Tested with the full 358 MB fasta file of refseq genomes and also with a smaller file of just the first three genomes from that file.